### PR TITLE
Introduce Chebyshev II filter for D‑term

### DIFF
--- a/src/main/common/filter.h
+++ b/src/main/common/filter.h
@@ -65,6 +65,10 @@ typedef struct biquadFilter_s {
     float weight;
 } biquadFilter_t;
 
+typedef struct cheby2Filter_s {
+    biquadFilter_t stage[3];
+} cheby2Filter_t;
+
 typedef struct phaseComp_s {
     float b0, b1, a1;
     float x1, y1;
@@ -121,7 +125,8 @@ void biquadFilterInitLPF(biquadFilter_t *filter, float filterFreq, uint32_t refr
 void biquadFilterInit(biquadFilter_t *filter, float filterFreq, uint32_t refreshRate, float Q, biquadFilterType_e filterType, float weight);
 void biquadFilterUpdate(biquadFilter_t *filter, float filterFreq, uint32_t refreshRate, float Q, biquadFilterType_e filterType, float weight);
 void biquadFilterUpdateLPF(biquadFilter_t *filter, float filterFreq, uint32_t refreshRate);
-void cheby2FilterInitLPF(biquadFilter_t *filter, float filterFreq, uint32_t refreshRate);
+void cheby2FilterInit(cheby2Filter_t *filter);
+float cheby2FilterApply(cheby2Filter_t *filter, float input);
 float biquadFilterApplyDF1(biquadFilter_t *filter, float input);
 float biquadFilterApplyDF1Weighted(biquadFilter_t *filter, float input);
 float biquadFilterApply(biquadFilter_t *filter, float input);

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -363,6 +363,7 @@ typedef union dtermLowpass_u {
     biquadFilter_t biquadFilter;
     pt2Filter_t pt2Filter;
     pt3Filter_t pt3Filter;
+    cheby2Filter_t cheby2Filter;
 } dtermLowpass_t;
 
 typedef struct pidCoefficient_s {

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -184,12 +184,12 @@ void pidInitFilters(const pidProfile_t *pidProfile)
         case FILTER_BIQUAD:
             if (pidProfile->dterm_lpf1_static_hz < pidFrequencyNyquist) {
 #ifdef USE_DYN_LPF
-                pidRuntime.dtermLowpassApplyFn = (filterApplyFnPtr)biquadFilterApplyDF1;
+                pidRuntime.dtermLowpassApplyFn = (filterApplyFnPtr)cheby2FilterApply;
 #else
-                pidRuntime.dtermLowpassApplyFn = (filterApplyFnPtr)biquadFilterApply;
+                pidRuntime.dtermLowpassApplyFn = (filterApplyFnPtr)cheby2FilterApply;
 #endif
                 for (int axis = FD_ROLL; axis <= FD_YAW; axis++) {
-                    cheby2FilterInitLPF(&pidRuntime.dtermLowpass[axis].biquadFilter, dterm_lpf1_init_hz, targetPidLooptime);
+                    cheby2FilterInit(&pidRuntime.dtermLowpass[axis].cheby2Filter);
                 }
             } else {
                 pidRuntime.dtermLowpassApplyFn = nullFilterApply;
@@ -226,9 +226,9 @@ void pidInitFilters(const pidProfile_t *pidProfile)
             break;
         case FILTER_BIQUAD:
             if (pidProfile->dterm_lpf2_static_hz < pidFrequencyNyquist) {
-                pidRuntime.dtermLowpass2ApplyFn = (filterApplyFnPtr)biquadFilterApply;
+                pidRuntime.dtermLowpass2ApplyFn = (filterApplyFnPtr)cheby2FilterApply;
                 for (int axis = FD_ROLL; axis <= FD_YAW; axis++) {
-                    cheby2FilterInitLPF(&pidRuntime.dtermLowpass2[axis].biquadFilter, pidProfile->dterm_lpf2_static_hz, targetPidLooptime);
+                    cheby2FilterInit(&pidRuntime.dtermLowpass2[axis].cheby2Filter);
                 }
             } else {
                 pidRuntime.dtermLowpassApplyFn = nullFilterApply;


### PR DESCRIPTION
## Summary
- add a Chebyshev II low‑pass filter implementation
- hook Chebyshev II filter into D‑term filter initialization
- set Chebyshev II stopband attenuation to 40 dB

## Testing
- `make test` *(fails: unable to parse `unit/pg.ld`)*

------
https://chatgpt.com/codex/tasks/task_e_68701bb2bc2c83248afd4318ec9390f5