### PR TITLE
Add Cheby2 pre-Dterm filter

### DIFF
--- a/src/main/common/filter.h
+++ b/src/main/common/filter.h
@@ -95,6 +95,14 @@ typedef struct meanAccumulator_s {
     int32_t count;
 } meanAccumulator_t;
 
+typedef struct {
+    biquadFilter_t stage[2];
+    int stageCount;
+} cheby2Filter_t;
+
+void cheby2FilterInit(cheby2Filter_t *filter);
+float cheby2FilterApply(cheby2Filter_t *filter, float input);
+
 float nullFilterApply(filter_t *filter, float input);
 
 float pt1FilterGain(float f_cut, float dT);

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -1193,6 +1193,7 @@ void FAST_CODE pidController(const pidProfile_t *pidProfile, timeUs_t currentTim
         }
 
         gyroRateDterm[axis] = pidRuntime.dtermNotchApplyFn((filter_t *) &pidRuntime.dtermNotch[axis], gyroRateDterm[axis]);
+        gyroRateDterm[axis] = cheby2FilterApply(&pidRuntime.dtermCheby2[axis], gyroRateDterm[axis]);
         gyroRateDterm[axis] = pidRuntime.dtermLowpassApplyFn((filter_t *) &pidRuntime.dtermLowpass[axis], gyroRateDterm[axis]);
         gyroRateDterm[axis] = pidRuntime.dtermLowpass2ApplyFn((filter_t *) &pidRuntime.dtermLowpass2[axis], gyroRateDterm[axis]);
     }

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -389,6 +389,7 @@ typedef struct pidRuntime_s {
     float previousPidSetpoint[XYZ_AXIS_COUNT];
     filterApplyFnPtr dtermNotchApplyFn;
     biquadFilter_t dtermNotch[XYZ_AXIS_COUNT];
+    cheby2Filter_t dtermCheby2[XYZ_AXIS_COUNT];
     filterApplyFnPtr dtermLowpassApplyFn;
     dtermLowpass_t dtermLowpass[XYZ_AXIS_COUNT];
     filterApplyFnPtr dtermLowpass2ApplyFn;

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -164,6 +164,10 @@ void pidInitFilters(const pidProfile_t *pidProfile)
         pidRuntime.dtermNotchApplyFn = nullFilterApply;
     }
 
+    for (int axis = FD_ROLL; axis <= FD_YAW; axis++) {
+        cheby2FilterInit(&pidRuntime.dtermCheby2[axis]);
+    }
+
     //1st Dterm Lowpass Filter
     uint16_t dterm_lpf1_init_hz = pidProfile->dterm_lpf1_static_hz;
 


### PR DESCRIPTION
## Summary
- add new Chebyshev type-II filter implementation
- initialize cheby2 D-term filter and run it before existing D-term LPFs

## Testing
- `make test` *(fails: unable to parse unit/pg.ld)*

------
https://chatgpt.com/codex/tasks/task_e_687addd877f88324b812099aa9094007