### PR TITLE
Streamlined gyro pipeline

### DIFF
--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -1386,6 +1386,13 @@ FAST_CODE void taskMainPidLoop(timeUs_t currentTimeUs)
     DEBUG_SET(DEBUG_CYCLETIME, 1, getAverageSystemLoadPercent());
 }
 
+FAST_CODE void taskGyroPipeline(timeUs_t currentTimeUs)
+{
+    gyroUpdate();
+    gyroFiltering(currentTimeUs);
+    taskMainPidLoop(currentTimeUs);
+}
+
 bool isCrashFlipModeActive(void)
 {
     return crashFlipModeActive;

--- a/src/main/fc/core.h
+++ b/src/main/fc/core.h
@@ -85,6 +85,7 @@ bool gyroFilterReady(void);
 bool pidLoopReady(void);
 void taskFiltering(timeUs_t currentTimeUs);
 void taskMainPidLoop(timeUs_t currentTimeUs);
+void taskGyroPipeline(timeUs_t currentTimeUs);
 
 bool isCrashFlipModeActive(void);
 int8_t calculateThrottlePercent(void);

--- a/src/main/fc/tasks.c
+++ b/src/main/fc/tasks.c
@@ -369,9 +369,7 @@ task_attribute_t task_attributes[TASK_COUNT] = {
     [TASK_STACK_CHECK] = DEFINE_TASK("STACKCHECK", NULL, NULL, taskStackCheck, TASK_PERIOD_HZ(10), TASK_PRIORITY_LOWEST),
 #endif
 
-    [TASK_GYRO] = DEFINE_TASK("GYRO", NULL, NULL, taskGyroSample, TASK_GYROPID_DESIRED_PERIOD, TASK_PRIORITY_REALTIME),
-    [TASK_FILTER] = DEFINE_TASK("FILTER", NULL, NULL, taskFiltering, TASK_GYROPID_DESIRED_PERIOD, TASK_PRIORITY_REALTIME),
-    [TASK_PID] = DEFINE_TASK("PID", NULL, NULL, taskMainPidLoop, TASK_GYROPID_DESIRED_PERIOD, TASK_PRIORITY_REALTIME),
+    [TASK_GYRO] = DEFINE_TASK("GYRO", NULL, NULL, taskGyroPipeline, TASK_GYROPID_DESIRED_PERIOD, TASK_PRIORITY_REALTIME),
 
 #ifdef USE_ACC
     [TASK_ACCEL] = DEFINE_TASK("ACC", NULL, NULL, taskUpdateAccelerometer, TASK_PERIOD_HZ(1000), TASK_PRIORITY_MEDIUM),
@@ -523,11 +521,7 @@ void tasksInit(void)
 
     if (sensors(SENSOR_GYRO)) {
         rescheduleTask(TASK_GYRO, gyro.sampleLooptime);
-        rescheduleTask(TASK_FILTER, gyro.targetLooptime);
-        rescheduleTask(TASK_PID, gyro.targetLooptime);
         setTaskEnabled(TASK_GYRO, true);
-        setTaskEnabled(TASK_FILTER, true);
-        setTaskEnabled(TASK_PID, true);
         schedulerEnableGyro();
     }
 

--- a/src/main/scheduler/scheduler.c
+++ b/src/main/scheduler/scheduler.c
@@ -553,13 +553,6 @@ FAST_CODE void scheduler(void)
             currentTimeUs = micros();
             taskExecutionTimeUs += schedulerExecuteTask(gyroTask, currentTimeUs);
 
-            if (gyroFilterReady()) {
-                taskExecutionTimeUs += schedulerExecuteTask(getTask(TASK_FILTER), currentTimeUs);
-            }
-            if (pidLoopReady()) {
-                taskExecutionTimeUs += schedulerExecuteTask(getTask(TASK_PID), currentTimeUs);
-            }
-
             // Check for incoming RX data. Don't do this in the checker as that is called repeatedly within
             // a given gyro loop, and ELRS takes a long time to process this and so can only be safely processed
             // before the checkers

--- a/src/test/unit/scheduler_stubs.c
+++ b/src/test/unit/scheduler_stubs.c
@@ -37,6 +37,7 @@ PG_RESET_TEMPLATE(schedulerConfig_t, schedulerConfig,
 void taskGyroSample(timeUs_t);
 void taskFiltering(timeUs_t);
 void taskMainPidLoop(timeUs_t);
+void taskGyroPipeline(timeUs_t);
 void taskUpdateAccelerometer(timeUs_t);
 void taskHandleSerial(timeUs_t);
 void taskUpdateBatteryVoltage(timeUs_t);
@@ -56,20 +57,8 @@ task_attribute_t task_attributes[TASK_COUNT] = {
     },
     [TASK_GYRO] = {
         .taskName = "GYRO",
-        .taskFunc = taskGyroSample,
+        .taskFunc = taskGyroPipeline,
         .desiredPeriodUs = TASK_PERIOD_HZ(TEST_GYRO_SAMPLE_HZ),
-        .staticPriority = TASK_PRIORITY_REALTIME,
-    },
-    [TASK_FILTER] = {
-        .taskName = "FILTER",
-        .taskFunc = taskFiltering,
-        .desiredPeriodUs = TASK_PERIOD_HZ(4000),
-        .staticPriority = TASK_PRIORITY_REALTIME,
-    },
-    [TASK_PID] = {
-        .taskName = "PID",
-        .taskFunc = taskMainPidLoop,
-        .desiredPeriodUs = TASK_PERIOD_HZ(4000),
         .staticPriority = TASK_PRIORITY_REALTIME,
     },
     [TASK_ACCEL] = {


### PR DESCRIPTION
## Summary
- implement `taskGyroPipeline` that runs gyro update, filtering and PID loop
- schedule the pipeline in place of separate gyro/filter/PID tasks
- update scheduler and unit test stubs for the new task
- adjust scheduler unit test for combined execution

## Testing
- `make` *(fails: arm-none-eabi-gcc not found)*
- `make test` *(fails: linker error with ld.gold)*

------
https://chatgpt.com/codex/tasks/task_e_687e7615a67883249765fdfa9bec78a6