### PR TITLE
Enable gyro pipeline ISR

### DIFF
--- a/src/main/drivers/accgyro/accgyro_mpu.c
+++ b/src/main/drivers/accgyro/accgyro_mpu.c
@@ -59,6 +59,7 @@
 #include "drivers/accgyro/accgyro_spi_lsm6dsv16x.h"
 #include "drivers/accgyro/accgyro_mpu.h"
 #include "drivers/accgyro/accgyro_spi_icm40609.h"
+#include "fc/core.h"
 
 #include "pg/pg.h"
 #include "pg/gyrodev.h"
@@ -131,6 +132,10 @@ busStatus_e mpuIntCallback(uint32_t arg)
 
     gyro->dataReady = true;
 
+    if (gyroPipelineIrqEnabled) {
+        taskGyroPipelineISR();
+    }
+
     return BUS_READY;
 }
 
@@ -150,6 +155,11 @@ static void mpuIntExtiHandler(extiCallbackRec_t *cb)
 
     if (gyro->gyroModeSPI == GYRO_EXTI_INT_DMA) {
         spiSequence(&gyro->dev, gyro->segments);
+    } else {
+        gyro->dataReady = true;
+        if (gyroPipelineIrqEnabled) {
+            taskGyroPipelineISR();
+        }
     }
 
     gyro->detectedEXTI++;
@@ -181,6 +191,7 @@ static void mpuIntExtiInit(gyroDev_t *gyro)
     EXTIHandlerInit(&gyro->exti, mpuIntExtiHandler);
     EXTIConfig(mpuIntIO, &gyro->exti, NVIC_PRIO_MPU_INT_EXTI, IOCFG_IN_FLOATING, BETAFLIGHT_EXTI_TRIGGER_RISING);
     EXTIEnable(mpuIntIO);
+    setGyroPipelineIrqEnabled(true);
 }
 
 bool mpuAccRead(accDev_t *acc)

--- a/src/main/drivers/accgyro/accgyro_spi_bmi160.c
+++ b/src/main/drivers/accgyro/accgyro_spi_bmi160.c
@@ -51,6 +51,7 @@
 #include "drivers/sensor.h"
 #include "drivers/system.h"
 #include "drivers/time.h"
+#include "fc/core.h"
 
 #include "sensors/gyro.h"
 
@@ -279,6 +280,10 @@ static busStatus_e bmi160Intcallback(uint32_t arg)
 
     gyro->dataReady = true;
 
+    if (gyroPipelineIrqEnabled) {
+        taskGyroPipelineISR();
+    }
+
     return BUS_READY;
 }
 #endif
@@ -296,6 +301,11 @@ static void bmi160ExtiHandler(extiCallbackRec_t *cb)
 
     if (gyro->gyroModeSPI == GYRO_EXTI_INT_DMA) {
         spiSequence(dev, gyro->segments);
+    } else {
+        gyro->dataReady = true;
+        if (gyroPipelineIrqEnabled) {
+            taskGyroPipelineISR();
+        }
     }
 
     gyro->detectedEXTI++;
@@ -314,6 +324,7 @@ static void bmi160IntExtiInit(gyroDev_t *gyro)
     EXTIHandlerInit(&gyro->exti, bmi160ExtiHandler);
     EXTIConfig(mpuIntIO, &gyro->exti, NVIC_PRIO_MPU_INT_EXTI, IOCFG_IN_FLOATING, BETAFLIGHT_EXTI_TRIGGER_RISING);
     EXTIEnable(mpuIntIO);
+    setGyroPipelineIrqEnabled(true);
 }
 
 static bool bmi160AccRead(accDev_t *acc)

--- a/src/main/drivers/accgyro/accgyro_spi_bmi270.c
+++ b/src/main/drivers/accgyro/accgyro_spi_bmi270.c
@@ -37,6 +37,7 @@
 #include "drivers/sensor.h"
 #include "drivers/system.h"
 #include "drivers/time.h"
+#include "fc/core.h"
 
 #include "sensors/gyro.h"
 
@@ -290,6 +291,10 @@ static busStatus_e bmi270Intcallback(uint32_t arg)
 
     gyro->dataReady = true;
 
+    if (gyroPipelineIrqEnabled) {
+        taskGyroPipelineISR();
+    }
+
     return BUS_READY;
 }
 #endif
@@ -307,6 +312,11 @@ static void bmi270ExtiHandler(extiCallbackRec_t *cb)
 
     if (gyro->gyroModeSPI == GYRO_EXTI_INT_DMA) {
         spiSequence(dev, gyro->segments);
+    } else {
+        gyro->dataReady = true;
+        if (gyroPipelineIrqEnabled) {
+            taskGyroPipelineISR();
+        }
     }
 
     gyro->detectedEXTI++;
@@ -325,6 +335,7 @@ static void bmi270IntExtiInit(gyroDev_t *gyro)
     EXTIHandlerInit(&gyro->exti, bmi270ExtiHandler);
     EXTIConfig(mpuIntIO, &gyro->exti, NVIC_PRIO_MPU_INT_EXTI, IOCFG_IN_FLOATING, BETAFLIGHT_EXTI_TRIGGER_RISING);
     EXTIEnable(mpuIntIO);
+    setGyroPipelineIrqEnabled(true);
 }
 
 static bool bmi270AccRead(accDev_t *acc)

--- a/src/main/drivers/accgyro/accgyro_spi_l3gd20.c
+++ b/src/main/drivers/accgyro/accgyro_spi_l3gd20.c
@@ -35,6 +35,7 @@
 #include "drivers/nvic.h"
 #include "drivers/sensor.h"
 #include "drivers/time.h"
+#include "fc/core.h"
 
 #include "drivers/accgyro/accgyro.h"
 
@@ -81,6 +82,9 @@ static void l3gd20ExtiHandler(extiCallbackRec_t *cb)
 {
     gyroDev_t *gyro = container_of(cb, gyroDev_t, exti);
     gyro->dataReady = true;
+    if (gyroPipelineIrqEnabled) {
+        taskGyroPipelineISR();
+    }
 }
 
 static void l3gd20IntExtiInit(gyroDev_t *gyro)
@@ -95,6 +99,7 @@ static void l3gd20IntExtiInit(gyroDev_t *gyro)
     EXTIHandlerInit(&gyro->exti, l3gd20ExtiHandler);
     EXTIConfig(mpuIntIO, &gyro->exti, NVIC_PRIO_MPU_INT_EXTI, IOCFG_IN_FLOATING, BETAFLIGHT_EXTI_TRIGGER_RISING);
     EXTIEnable(mpuIntIO);
+    setGyroPipelineIrqEnabled(true);
 }
 
 void l3gd20GyroInit(gyroDev_t *gyro)

--- a/src/main/drivers/accgyro/accgyro_spi_lsm6dso.c
+++ b/src/main/drivers/accgyro/accgyro_spi_lsm6dso.c
@@ -31,11 +31,15 @@
 #include "drivers/exti.h"
 #include "drivers/io.h"
 #include "drivers/io_impl.h"
+#include "fc/core.h"
 
 void lsm6dsoExtiHandler(extiCallbackRec_t *cb)
 {
     gyroDev_t *gyro = container_of(cb, gyroDev_t, exti);
     gyro->dataReady = true;
+    if (gyroPipelineIrqEnabled) {
+        taskGyroPipelineISR();
+    }
 }
 
 bool lsm6dsoAccRead(accDev_t *acc)

--- a/src/main/drivers/accgyro/accgyro_spi_lsm6dso_init.c
+++ b/src/main/drivers/accgyro/accgyro_spi_lsm6dso_init.c
@@ -34,6 +34,7 @@
 #include "drivers/nvic.h"
 #include "drivers/sensor.h"
 #include "drivers/time.h"
+#include "fc/core.h"
 
 // 10 MHz max SPI frequency
 #define LSM6DSO_MAX_SPI_CLK_HZ 10000000
@@ -162,6 +163,7 @@ static void lsm6dsoIntExtiInit(gyroDev_t *gyro)
     EXTIHandlerInit(&gyro->exti, lsm6dsoExtiHandler);
     EXTIConfig(mpuIntIO, &gyro->exti, NVIC_PRIO_MPU_INT_EXTI, IOCFG_IN_FLOATING, BETAFLIGHT_EXTI_TRIGGER_RISING);
     EXTIEnable(mpuIntIO);
+    setGyroPipelineIrqEnabled(true);
 }
 
 static void lsm6dsoSpiGyroInit(gyroDev_t *gyro)

--- a/src/main/fc/core.c
+++ b/src/main/fc/core.c
@@ -1414,3 +1414,26 @@ bool isLaunchControlActive(void)
     return false;
 #endif
 }
+
+FAST_DATA_ZERO_INIT bool gyroPipelineIrqEnabled = false;
+
+void setGyroPipelineIrqEnabled(bool enabled)
+{
+    gyroPipelineIrqEnabled = enabled;
+}
+
+FAST_CODE void taskGyroPipeline(timeUs_t currentTimeUs)
+{
+    taskGyroSample(currentTimeUs);
+    if (gyroFilterReady()) {
+        taskFiltering(currentTimeUs);
+    }
+    if (pidLoopReady()) {
+        taskMainPidLoop(currentTimeUs);
+    }
+}
+
+FAST_CODE void taskGyroPipelineISR(void)
+{
+    taskGyroPipeline(microsISR());
+}

--- a/src/main/fc/core.h
+++ b/src/main/fc/core.h
@@ -85,6 +85,10 @@ bool gyroFilterReady(void);
 bool pidLoopReady(void);
 void taskFiltering(timeUs_t currentTimeUs);
 void taskMainPidLoop(timeUs_t currentTimeUs);
+void taskGyroPipeline(timeUs_t currentTimeUs);
+void taskGyroPipelineISR(void);
+extern bool gyroPipelineIrqEnabled;
+void setGyroPipelineIrqEnabled(bool enabled);
 
 bool isCrashFlipModeActive(void);
 int8_t calculateThrottlePercent(void);

--- a/src/main/scheduler/scheduler.c
+++ b/src/main/scheduler/scheduler.c
@@ -513,7 +513,7 @@ FAST_CODE void scheduler(void)
     }
 #endif
 
-    if (gyroEnabled) {
+    if (gyroEnabled && !gyroPipelineIrqEnabled) {
         // Realtime gyro/filtering/PID tasks get complete priority
         task_t *gyroTask = getTask(TASK_GYRO);
         nowCycles = getCycleCounter();
@@ -700,7 +700,7 @@ FAST_CODE void scheduler(void)
     nowCycles = getCycleCounter();
     schedLoopRemainingCycles = cmpTimeCycles(nextTargetCycles, nowCycles);
 
-    if (!gyroEnabled || (schedLoopRemainingCycles > (int32_t)clockMicrosToCycles(CHECK_GUARD_MARGIN_US))) {
+    if (!gyroEnabled || gyroPipelineIrqEnabled || (schedLoopRemainingCycles > (int32_t)clockMicrosToCycles(CHECK_GUARD_MARGIN_US))) {
         currentTimeUs = micros();
 
         // Update task dynamic priorities
@@ -770,7 +770,7 @@ FAST_CODE void scheduler(void)
             // Allow a little extra time
             taskRequiredTimeCycles += taskGuardCycles;
 
-            if (!gyroEnabled || firstSchedulingOpportunity || (taskRequiredTimeCycles < schedLoopRemainingCycles)) {
+            if (!gyroEnabled || gyroPipelineIrqEnabled || firstSchedulingOpportunity || (taskRequiredTimeCycles < schedLoopRemainingCycles)) {
                 uint32_t antipatedEndCycles = nowCycles + taskRequiredTimeCycles;
                 taskExecutionTimeUs += schedulerExecuteTask(selectedTask, currentTimeUs);
                 nowCycles = getCycleCounter();


### PR DESCRIPTION
## Summary
- add gyro pipeline execution functions
- trigger gyro pipeline from driver interrupts
- let scheduler ignore polling when interrupts are active

## Testing
- `make test` *(fails: unable to link unit tests)*

------
https://chatgpt.com/codex/tasks/task_e_687e762badd483248cb47eeff1a19f72