### PR TITLE
Make dynamic LPF throttle params configurable

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1059,6 +1059,10 @@ const clivalue_t valueTable[] = {
     { PARAM_NAME_MIXER_TYPE,        VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_MIXER_TYPE }, PG_MIXER_CONFIG, offsetof(mixerConfig_t, mixer_type) },
     { "crashflip_motor_percent",    VAR_UINT8 |  MASTER_VALUE,  .config.minmaxUnsigned = { 0, 100 }, PG_MIXER_CONFIG, offsetof(mixerConfig_t, crashflip_motor_percent) },
     { "crashflip_rate",             VAR_UINT8 |  MASTER_VALUE,  .config.minmaxUnsigned = { 0, 250 }, PG_MIXER_CONFIG, offsetof(mixerConfig_t, crashflip_rate) },
+#ifdef USE_DYN_LPF
+    { "dyn_lpf_throttle_update_delay_us", VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 0, UINT16_MAX }, PG_MIXER_CONFIG, offsetof(mixerConfig_t, dyn_lpf_throttle_update_delay_us) },
+    { "dyn_lpf_throttle_steps",          VAR_UINT16 | MASTER_VALUE, .config.minmaxUnsigned = { 1, UINT16_MAX }, PG_MIXER_CONFIG, offsetof(mixerConfig_t, dyn_lpf_throttle_steps) },
+#endif
 #ifdef USE_RPM_LIMIT
     { "rpm_limit",                  VAR_INT8   |  MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_MIXER_CONFIG, offsetof(mixerConfig_t, rpm_limit) },
     { "rpm_limit_p",                VAR_UINT16 |  MASTER_VALUE,  .config.minmaxUnsigned = { 0, 100 },        PG_MIXER_CONFIG, offsetof(mixerConfig_t, rpm_limit_p) },

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -67,8 +67,10 @@
 
 #include "mixer.h"
 
-#define DYN_LPF_THROTTLE_STEPS             100
-#define DYN_LPF_THROTTLE_UPDATE_DELAY_US  5000 // minimum of 5ms between updates
+#ifdef USE_DYN_LPF
+#define DYN_LPF_THROTTLE_STEPS             mixerConfig()->dyn_lpf_throttle_steps
+#define DYN_LPF_THROTTLE_UPDATE_DELAY_US   mixerConfig()->dyn_lpf_throttle_update_delay_us
+#endif
 
 #define CRASHFLIP_MOTOR_DEADBAND         0.02f // 2%; send 'disarm' value to motors below this drive value
 #define CRASHFLIP_STICK_DEADBAND         0.15f // 15%

--- a/src/main/flight/mixer.h
+++ b/src/main/flight/mixer.h
@@ -97,6 +97,10 @@ typedef struct mixerConfig_s {
     uint8_t crashflip_motor_percent;
     uint8_t crashflip_rate;
     uint8_t mixer_type;
+#ifdef USE_DYN_LPF
+    uint16_t dyn_lpf_throttle_update_delay_us;
+    uint16_t dyn_lpf_throttle_steps;
+#endif
 #ifdef USE_RPM_LIMIT
     bool rpm_limit;
     uint16_t rpm_limit_p;

--- a/src/main/flight/mixer_init.c
+++ b/src/main/flight/mixer_init.c
@@ -60,6 +60,10 @@ void pgResetFn_mixerConfig(mixerConfig_t *mixerConfig)
     mixerConfig->crashflip_rate = 0;
 #endif
     mixerConfig->mixer_type = MIXER_LEGACY;
+#ifdef USE_DYN_LPF
+    mixerConfig->dyn_lpf_throttle_update_delay_us = 2000; // 2ms default
+    mixerConfig->dyn_lpf_throttle_steps = 200;            // finer granularity
+#endif
 #ifdef USE_RPM_LIMIT
     mixerConfig->rpm_limit = false;
     mixerConfig->rpm_limit_p = 25;


### PR DESCRIPTION
## Summary
- expose throttle update delay and steps as mixer settings
- default to shorter delay and more steps
- hook parameters up in CLI and mixer code

## Testing
- `gcc -O2 bench/dyn_lpf_bench.c -lm -o bench/bench_default && ./bench/bench_default` *(fails: No such file or directory? Wait we removed bench directory)*
- `make targets` *(fails: arm-none-eabi-gcc not in the PATH)*

------
https://chatgpt.com/codex/tasks/task_e_687e7637b858832480f85b4301f182dc