### PR TITLE
Add biquad filter response option

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -378,6 +378,11 @@ static const char * const lookupTableDtermLowpassType[] = {
     "PT3",
 };
 
+const char * const lookupTableBiquadResponse[] = {
+    "BUTTER",
+    "BESSEL",
+};
+
 static const char * const lookupTableFailsafe[] = {
     "AUTO-LAND", "DROP", "GPS-RESCUE"
 };
@@ -654,6 +659,7 @@ const lookupTableEntry_t lookupTables[] = {
 #endif
     LOOKUP_TABLE_ENTRY(lookupTableLowpassType),
     LOOKUP_TABLE_ENTRY(lookupTableDtermLowpassType),
+    LOOKUP_TABLE_ENTRY(lookupTableBiquadResponse),
     LOOKUP_TABLE_ENTRY(lookupTableFailsafe),
     LOOKUP_TABLE_ENTRY(lookupTableFailsafeSwitchMode),
     LOOKUP_TABLE_ENTRY(lookupTableCrashRecovery),
@@ -1717,6 +1723,7 @@ const clivalue_t valueTable[] = {
 #endif
     { "pwr_on_arm_grace",           VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 30 }, PG_SYSTEM_CONFIG, offsetof(systemConfig_t, powerOnArmingGraceTime) },
     { "enable_stick_arming",        VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_SYSTEM_CONFIG, offsetof(systemConfig_t, enableStickArming) },
+    { PARAM_NAME_BIQUAD_RESPONSE,    VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_BIQUAD_RESPONSE }, PG_SYSTEM_CONFIG, offsetof(systemConfig_t, biquad_response) },
 
 // PG_VTX_CONFIG
 #ifdef USE_VTX_COMMON

--- a/src/main/cli/settings.h
+++ b/src/main/cli/settings.h
@@ -69,6 +69,7 @@ typedef enum {
 #endif
     TABLE_GYRO_LPF_TYPE,
     TABLE_DTERM_LPF_TYPE,
+    TABLE_BIQUAD_RESPONSE,
     TABLE_FAILSAFE,
     TABLE_FAILSAFE_SWITCH_MODE,
     TABLE_CRASH_RECOVERY,
@@ -278,6 +279,7 @@ extern const char * const lookupTableOsdDisplayPortDevice[];
 extern const char * const lookupTableFeedforwardAveraging[];
 
 extern const char * const lookupTableOffOn[];
+extern const char * const lookupTableBiquadResponse[];
 
 extern const char * const lookupTableSimplifiedTuningPidsMode[];
 

--- a/src/main/cms/cms_menu_imu.c
+++ b/src/main/cms/cms_menu_imu.c
@@ -746,6 +746,7 @@ static uint16_t gyroConfig_gyro_soft_notch_hz_1;
 static uint16_t gyroConfig_gyro_soft_notch_cutoff_1;
 static uint16_t gyroConfig_gyro_soft_notch_hz_2;
 static uint16_t gyroConfig_gyro_soft_notch_cutoff_2;
+static uint8_t systemConfig_biquad_response;
 
 static const void *cmsx_menuGyro_onEnter(displayPort_t *pDisp)
 {
@@ -757,6 +758,7 @@ static const void *cmsx_menuGyro_onEnter(displayPort_t *pDisp)
     gyroConfig_gyro_soft_notch_cutoff_1 = gyroConfig()->gyro_soft_notch_cutoff_1;
     gyroConfig_gyro_soft_notch_hz_2 = gyroConfig()->gyro_soft_notch_hz_2;
     gyroConfig_gyro_soft_notch_cutoff_2 = gyroConfig()->gyro_soft_notch_cutoff_2;
+    systemConfig_biquad_response = systemConfig()->biquad_response;
 
     return NULL;
 }
@@ -772,6 +774,7 @@ static const void *cmsx_menuGyro_onExit(displayPort_t *pDisp, const OSD_Entry *s
     gyroConfigMutable()->gyro_soft_notch_cutoff_1 = gyroConfig_gyro_soft_notch_cutoff_1;
     gyroConfigMutable()->gyro_soft_notch_hz_2 = gyroConfig_gyro_soft_notch_hz_2;
     gyroConfigMutable()->gyro_soft_notch_cutoff_2 = gyroConfig_gyro_soft_notch_cutoff_2;
+    systemConfigMutable()->biquad_response = systemConfig_biquad_response;
 
     return NULL;
 }
@@ -788,6 +791,7 @@ static const OSD_Entry cmsx_menuFilterGlobalEntries[] =
     { "GYRO NF1C",  OME_UINT16, NULL, &(OSD_UINT16_t) { &gyroConfig_gyro_soft_notch_cutoff_1, 0, 500, 1 } },
     { "GYRO NF2",   OME_UINT16, NULL, &(OSD_UINT16_t) { &gyroConfig_gyro_soft_notch_hz_2,     0, 500, 1 } },
     { "GYRO NF2C",  OME_UINT16, NULL, &(OSD_UINT16_t) { &gyroConfig_gyro_soft_notch_cutoff_2, 0, 500, 1 } },
+    { "BQ RESP",   OME_TAB,   NULL, &(OSD_TAB_t){ &systemConfig_biquad_response, FILTER_BIQUAD_BESSEL, lookupTableBiquadResponse } },
 
     { "BACK", OME_Back, NULL, NULL },
     { NULL, OME_END, NULL, NULL}

--- a/src/main/common/filter.c
+++ b/src/main/common/filter.c
@@ -25,10 +25,17 @@
 #include "platform.h"
 
 #include "common/filter.h"
+#include "config/config.h"
 #include "common/maths.h"
 #include "common/utils.h"
 
-#define BIQUAD_Q 1.0f / sqrtf(2.0f)     /* quality factor - 2nd order butterworth*/
+#define BIQUAD_Q_BUTTERWORTH (1.0f / sqrtf(2.0f))
+#define BIQUAD_Q_BESSEL     (0.57735f)
+
+static float getBiquadQ(void)
+{
+    return systemConfig()->biquad_response == FILTER_BIQUAD_BESSEL ? BIQUAD_Q_BESSEL : BIQUAD_Q_BUTTERWORTH;
+}
 
 // PTn cutoff correction = 1 / sqrt(2^(1/n) - 1)
 #define CUTOFF_CORRECTION_PT2 1.553773974f
@@ -168,7 +175,7 @@ float filterGetNotchQ(float centerFreq, float cutoffFreq)
 /* sets up a biquad filter as a 2nd order butterworth LPF */
 void biquadFilterInitLPF(biquadFilter_t *filter, float filterFreq, uint32_t refreshRate)
 {
-    biquadFilterInit(filter, filterFreq, refreshRate, BIQUAD_Q, FILTER_LPF, 1.0f);
+    biquadFilterInit(filter, filterFreq, refreshRate, getBiquadQ(), FILTER_LPF, 1.0f);
 }
 
 void biquadFilterInit(biquadFilter_t *filter, float filterFreq, uint32_t refreshRate, float Q, biquadFilterType_e filterType, float weight)
@@ -229,7 +236,7 @@ FAST_CODE void biquadFilterUpdate(biquadFilter_t *filter, float filterFreq, uint
 
 FAST_CODE void biquadFilterUpdateLPF(biquadFilter_t *filter, float filterFreq, uint32_t refreshRate)
 {
-    biquadFilterUpdate(filter, filterFreq, refreshRate, BIQUAD_Q, FILTER_LPF, 1.0f);
+    biquadFilterUpdate(filter, filterFreq, refreshRate, getBiquadQ(), FILTER_LPF, 1.0f);
 }
 
 /* Computes a biquadFilter_t filter on a sample (slightly less precise than df2 but works in dynamic mode) */

--- a/src/main/common/filter.h
+++ b/src/main/common/filter.h
@@ -40,6 +40,11 @@ typedef enum {
     FILTER_BPF,
 } biquadFilterType_e;
 
+typedef enum {
+    FILTER_BIQUAD_BUTTERWORTH = 0,
+    FILTER_BIQUAD_BESSEL,
+} biquadResponse_e;
+
 typedef struct pt1Filter_s {
     float state;
     float k;

--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -48,6 +48,8 @@
 #include "fc/rc_controls.h"
 #include "fc/runtime_config.h"
 
+#include "common/filter.h"
+
 #include "flight/failsafe.h"
 #include "flight/imu.h"
 #include "flight/mixer.h"
@@ -119,6 +121,7 @@ PG_RESET_TEMPLATE(systemConfig_t, systemConfig,
     .hseMhz = SYSTEM_HSE_MHZ,  // Only used for F4 and G4 targets
     .configurationState = CONFIGURATION_STATE_UNCONFIGURED,
     .enableStickArming = false,
+    .biquad_response = FILTER_BIQUAD_BUTTERWORTH,
 );
 
 bool isEepromWriteInProgress(void)

--- a/src/main/config/config.h
+++ b/src/main/config/config.h
@@ -42,6 +42,7 @@ typedef struct systemConfig_s {
     uint8_t hseMhz;                 // Only used for F4 and G4 targets
     uint8_t configurationState;     // The state of the configuration (defaults / configured)
     uint8_t enableStickArming; // boolean that determines whether stick arming can be used
+    uint8_t biquad_response;        // Filter response type for biquad lowpass
 } systemConfig_t;
 
 PG_DECLARE(systemConfig_t, systemConfig);

--- a/src/main/fc/parameter_names.h
+++ b/src/main/fc/parameter_names.h
@@ -25,6 +25,7 @@
 #define PARAM_NAME_GYRO_LPF1_STATIC_HZ "gyro_lpf1_static_hz"
 #define PARAM_NAME_GYRO_LPF2_TYPE "gyro_lpf2_type"
 #define PARAM_NAME_GYRO_LPF2_STATIC_HZ "gyro_lpf2_static_hz"
+#define PARAM_NAME_BIQUAD_RESPONSE "biquad_response"
 #define PARAM_NAME_GYRO_ENABLE_MASK "gyro_enable_bitmask"
 #define PARAM_NAME_DYN_NOTCH_MAX_HZ "dyn_notch_max_hz"
 #define PARAM_NAME_DYN_NOTCH_COUNT "dyn_notch_count"


### PR DESCRIPTION
## Summary
- allow selecting Bessel vs Butterworth biquad response
- expose response option through CLI and OSD

## Testing
- `make test` *(fails: clang missing BlocksRuntime)*

------
https://chatgpt.com/codex/tasks/task_e_688422a63ab08324bd1229134b471640