### PR TITLE
Motor Output Limit Dynamic Idle Adjustment

### DIFF
--- a/src/main/flight/mixer_init.c
+++ b/src/main/flight/mixer_init.c
@@ -336,8 +336,9 @@ void initEscEndpoints(void)
 void mixerInitProfile(void)
 {
 #ifdef USE_DYN_IDLE
+    const float motorOutputLimit = currentPidProfile->motor_output_limit * 0.01f;
     if (useDshotTelemetry) {
-        mixerRuntime.dynIdleMinRps = currentPidProfile->dyn_idle_min_rpm * 100.0f / 60.0f;
+        mixerRuntime.dynIdleMinRps = currentPidProfile->dyn_idle_min_rpm * motorOutputLimit * 100.0f / 60.0f;
     } else {
         mixerRuntime.dynIdleMinRps = 0.0f;
     }


### PR DESCRIPTION
## Summary
- scale dynamic idle minimum RPM target by motor output limit factor

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6893729b669c83249be21e58bb6d1b78