### PR TITLE
Add gyroscopic D-term TPA multiplier

### DIFF
--- a/src/main/blackbox/blackbox.c
+++ b/src/main/blackbox/blackbox.c
@@ -1534,6 +1534,7 @@ static bool blackboxWriteSysinfo(void)
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_TPA_MODE, "%d",               currentPidProfile->tpa_mode);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_TPA_RATE, "%d",               currentPidProfile->tpa_rate);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_TPA_BREAKPOINT, "%d",         currentPidProfile->tpa_breakpoint);
+        BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_TPA_D_GSCOPIC, "%d",         currentPidProfile->tpa_d_gscopic);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_TPA_LOW_RATE, "%d",           currentPidProfile->tpa_low_rate);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_TPA_LOW_BREAKPOINT, "%d",     currentPidProfile->tpa_low_breakpoint);
         BLACKBOX_PRINT_HEADER_LINE(PARAM_NAME_TPA_LOW_ALWAYS, "%d",         currentPidProfile->tpa_low_always);

--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1389,6 +1389,7 @@ const clivalue_t valueTable[] = {
     { PARAM_NAME_TPA_MODE,             VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_TPA_MODE }, PG_PID_PROFILE, offsetof(pidProfile_t, tpa_mode) },
     { PARAM_NAME_TPA_RATE,          VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, TPA_MAX}, PG_PID_PROFILE, offsetof(pidProfile_t, tpa_rate) },
     { PARAM_NAME_TPA_BREAKPOINT,    VAR_UINT16 | PROFILE_VALUE, .config.minmaxUnsigned = { PWM_RANGE_MIN, PWM_RANGE_MAX }, PG_PID_PROFILE, offsetof(pidProfile_t, tpa_breakpoint) },
+    { PARAM_NAME_TPA_D_GSCOPIC,     VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 100 }, PG_PID_PROFILE, offsetof(pidProfile_t, tpa_d_gscopic) },
     { PARAM_NAME_TPA_LOW_RATE,            VAR_INT8  | PROFILE_VALUE, .config.minmax = { TPA_LOW_RATE_MIN, TPA_MAX }, PG_PID_PROFILE, offsetof(pidProfile_t, tpa_low_rate) },
     { PARAM_NAME_TPA_LOW_BREAKPOINT,      VAR_UINT16 | PROFILE_VALUE, .config.minmaxUnsigned = { PWM_RANGE_MIN, PWM_RANGE_MAX }, PG_PID_PROFILE, offsetof(pidProfile_t, tpa_low_breakpoint) },
     { PARAM_NAME_TPA_LOW_ALWAYS, VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_PID_PROFILE, offsetof(pidProfile_t, tpa_low_always) },

--- a/src/main/cms/cms_menu_imu.c
+++ b/src/main/cms/cms_menu_imu.c
@@ -258,6 +258,7 @@ static uint16_t cmsx_tpa_breakpoint;
 static int8_t cmsx_tpa_low_rate;
 static uint16_t cmsx_tpa_low_breakpoint;
 static uint8_t cmsx_tpa_low_always;
+static uint8_t cmsx_tpa_d_gscopic;
 static uint8_t cmsx_landing_disarm_threshold;
 
 static const void *cmsx_simplifiedTuningOnEnter(displayPort_t *pDisp)
@@ -604,6 +605,7 @@ static const void *cmsx_profileOtherOnEnter(displayPort_t *pDisp)
     cmsx_tpa_low_rate = pidProfile->tpa_low_rate;
     cmsx_tpa_low_breakpoint = pidProfile->tpa_low_breakpoint;
     cmsx_tpa_low_always = pidProfile->tpa_low_always;
+    cmsx_tpa_d_gscopic = pidProfile->tpa_d_gscopic;
     cmsx_landing_disarm_threshold = pidProfile->landing_disarm_threshold;
     return NULL;
 }
@@ -662,6 +664,7 @@ static const void *cmsx_profileOtherOnExit(displayPort_t *pDisp, const OSD_Entry
     pidProfile->tpa_low_rate = cmsx_tpa_low_rate;
     pidProfile->tpa_low_breakpoint = cmsx_tpa_low_breakpoint;
     pidProfile->tpa_low_always = cmsx_tpa_low_always;
+    pidProfile->tpa_d_gscopic = cmsx_tpa_d_gscopic;
     pidProfile->landing_disarm_threshold = cmsx_landing_disarm_threshold;
 
     initEscEndpoints();
@@ -720,6 +723,7 @@ static const OSD_Entry cmsx_menuProfileOtherEntries[] = {
 
     { "TPA RATE",      OME_FLOAT,  NULL, &(OSD_FLOAT_t) { &cmsx_tpa_rate, 0, 100, 1, 10} },
     { "TPA BRKPT",     OME_UINT16, NULL, &(OSD_UINT16_t){ &cmsx_tpa_breakpoint, 1000, 2000, 10} },
+    { "TPA D GSC",    OME_UINT8,  NULL, &(OSD_UINT8_t) { &cmsx_tpa_d_gscopic, 0, 100, 1 } },
     { "TPA LOW RATE",  OME_INT8,   NULL, &(OSD_INT8_t) { &cmsx_tpa_low_rate, TPA_LOW_RATE_MIN, TPA_MAX , 1} },
     { "TPA LOW BRKPT", OME_UINT16, NULL, &(OSD_UINT16_t){ &cmsx_tpa_low_breakpoint, 1000, 2000, 10} },
     { "TPA LOW ALWYS", OME_Bool,   NULL, &cmsx_tpa_low_always },

--- a/src/main/fc/parameter_names.h
+++ b/src/main/fc/parameter_names.h
@@ -59,6 +59,7 @@
 #define PARAM_NAME_TPA_LOW_BREAKPOINT "tpa_low_breakpoint"
 #define PARAM_NAME_TPA_LOW_ALWAYS "tpa_low_always"
 #define PARAM_NAME_TPA_MODE "tpa_mode"
+#define PARAM_NAME_TPA_D_GSCOPIC "tpa_d_gscopic"
 #define PARAM_NAME_TPA_CURVE_TYPE "tpa_curve_type"
 #define PARAM_NAME_TPA_CURVE_STALL_THROTTLE "tpa_curve_stall_throttle"
 #define PARAM_NAME_TPA_CURVE_PID_THR0 "tpa_curve_pid_thr0"

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -228,6 +228,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .tpa_mode = TPA_MODE_D,
         .tpa_rate = 65,
         .tpa_breakpoint = 1350,
+        .tpa_d_gscopic = 0,
         .angle_feedforward_smoothing_ms = 80,
         .angle_earth_ref = 100,
         .horizon_delay_ms = 500, // 500ms time constant on any increase in horizon strength
@@ -426,8 +427,11 @@ static float getTpaFactorClassic(float tpaArgument)
         if (!pidRuntime.tpaLowAlways && !isTpaLowFaded) {
             isTpaLowFaded = true;
         }
+        const float tpaRateD = tpaRate * (1.0f + pidRuntime.tpaDMultiplier);
+        pidRuntime.tpaFactorD = 1.0f - constrainf(tpaRateD, 0.0f, 1.0f);
     } else {
         tpaRate = pidRuntime.tpaLowMultiplier * (pidRuntime.tpaLowBreakpoint - tpaArgument);
+        pidRuntime.tpaFactorD = 1.0f - tpaRate;
     }
 
     return 1.0f - tpaRate;
@@ -459,6 +463,13 @@ void pidUpdateTpaFactor(float throttle)
 
     DEBUG_SET(DEBUG_TPA, 0, lrintf(tpaFactor * 1000));
     pidRuntime.tpaFactor = tpaFactor;
+#ifdef USE_ADVANCED_TPA
+    if (pidRuntime.tpaCurveType != TPA_CURVE_CLASSIC) {
+        const float tpaRate = 1.0f - tpaFactor;
+        const float tpaRateD = tpaRate * (1.0f + pidRuntime.tpaDMultiplier);
+        pidRuntime.tpaFactorD = 1.0f - constrainf(tpaRateD, 0.0f, 1.0f);
+    }
+#endif
 
 #ifdef USE_WING
     switch (currentPidProfile->yaw_type) {
@@ -1032,7 +1043,7 @@ static float getTpaFactor(const pidProfile_t *pidProfile, int axis, term_e term)
     case TERM_P:
         return tpaActive ? tpaFactor : 1.0f;
     case TERM_D:
-        return tpaFactor;
+        return pidRuntime.tpaFactorD;
 #ifdef USE_WING
     case TERM_S:
         return tpaActive ? pidRuntime.tpaFactorSterm[axis] : 1.0f;

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -291,6 +291,7 @@ typedef struct pidProfile_s {
     uint8_t tpa_mode;                       // Controls which PID terms TPA effects
     uint8_t tpa_rate;                       // Percent reduction in P or D at full throttle
     uint16_t tpa_breakpoint;                // Breakpoint where TPA is activated
+    uint8_t tpa_d_gscopic;                  // Additional D-term TPA multiplier, 0 = off, 100 = double
 
     uint8_t angle_feedforward_smoothing_ms; // Smoothing factor for angle feedforward as time constant in milliseconds
     uint8_t angle_earth_ref;                // Control amount of "co-ordination" from yaw into roll while pitched forward in angle mode
@@ -428,8 +429,10 @@ typedef struct pidRuntime_s {
     bool zeroThrottleItermReset;
     bool levelRaceMode;
     float tpaFactor;
+    float tpaFactorD;
     float tpaBreakpoint;
     float tpaMultiplier;
+    float tpaDMultiplier;
     float tpaLowBreakpoint;
     float tpaLowMultiplier;
     bool tpaLowAlways;

--- a/src/main/flight/pid_init.c
+++ b/src/main/flight/pid_init.c
@@ -567,11 +567,13 @@ void pidInitConfig(const pidProfile_t *pidProfile)
     pidRuntime.tpaBreakpoint = constrainf((pidProfile->tpa_breakpoint - PWM_RANGE_MIN) / 1000.0f, 0.0f, 0.99f);
     // default of 1350 returns 0.35. range limited to 0 to 0.99
     pidRuntime.tpaMultiplier = (pidProfile->tpa_rate / 100.0f) / (1.0f - pidRuntime.tpaBreakpoint);
+    pidRuntime.tpaDMultiplier = (pidProfile->tpa_mode == TPA_MODE_PD) ? pidProfile->tpa_d_gscopic / 100.0f : 0.0f;
     // it is assumed that tpaLowBreakpoint is always less than or equal to tpaBreakpoint
     pidRuntime.tpaLowBreakpoint = constrainf((pidProfile->tpa_low_breakpoint - PWM_RANGE_MIN) / 1000.0f, 0.01f, 1.0f);
     pidRuntime.tpaLowBreakpoint = MIN(pidRuntime.tpaLowBreakpoint, pidRuntime.tpaBreakpoint);
     pidRuntime.tpaLowMultiplier = pidProfile->tpa_low_rate / (100.0f * pidRuntime.tpaLowBreakpoint);
     pidRuntime.tpaLowAlways = pidProfile->tpa_low_always;
+    pidRuntime.tpaFactorD = 1.0f;
 
     pidRuntime.useEzDisarm = pidProfile->landing_disarm_threshold > 0;
     pidRuntime.landingDisarmThreshold = pidProfile->landing_disarm_threshold * 10.0f;


### PR DESCRIPTION
## Summary
- add `tpa_d_gscopic` parameter to boost D-term TPA when PD mode is active
- log and expose the new multiplier through CLI, blackbox and CMS menu
- guard D-term scaling behind `USE_ADVANCED_TPA` so classic builds compile

## Testing
- `make SEQUREH7V2` *(fails: arm-none-eabi-gcc missing and toolchain download blocked)*
- `make test` *(fails: build interrupted during long compile)*

------
https://chatgpt.com/codex/tasks/task_e_6899db6de6ac8324be7e15a2bfdc0161